### PR TITLE
bugfix: add underscore as dependency for templates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.5
+- Add underscore.js as a default dependency for compiled templates
+
 ## 0.0.4 (2016-09-21)
 - Cleaned up a bit and released to NPM as requirejs-undertemplate
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "requirejs-undertemplate",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": [
     "tpl.js"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "requirejs-undertemplate",
   "description": "Require.js loader plugin for underscore.js templates",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "keywords": [
     "requirejs",
     "underscore",

--- a/tpl.js
+++ b/tpl.js
@@ -6,7 +6,7 @@
 // Using UnderscoreJS micro-templates at http://underscorejs.org/#template
 // Using and RequireJS text.js at http://requirejs.org/docs/api.html#text
 // @author JF Paradis
-// @version 0.0.2
+// @version 0.0.5
 //
 // Released under the MIT license
 //
@@ -35,10 +35,10 @@ define(['text', 'underscore'], function (text, _) {
     'use strict';
 
     var buildMap = {},
-        buildTemplateSource = "define('{pluginName}!{moduleName}', function () { return {source}; });\n";
+        buildTemplateSource = "define('{pluginName}!{moduleName}', ['underscore'], function (_) { return {source}; });\n";
 
     return {
-        version: '0.0.2',
+        version: '0.0.5',
 
         load: function (moduleName, parentRequire, onload, config) {
 


### PR DESCRIPTION
Fix compiled templates so they do not depend on global underscore (`_`).